### PR TITLE
enhancement showcase (ajax, gravatar, nested, delete)

### DIFF
--- a/assets/comments.css
+++ b/assets/comments.css
@@ -9,7 +9,7 @@ Comments Plugin Styles
 	border-top: gray solid 2px;
 }
 .comment:first-child {
-  margin-top: 0;
+  margin-top: 0px;
 }
 .comment,
 .comment-body {
@@ -43,7 +43,7 @@ Comments Plugin Styles
   vertical-align: bottom;
 }
 .comment-heading {
-  margin-top: 0;
+  margin-top: 0px;
   margin-bottom: 5px;
   border-bottom: gray dashed 1px;
 }
@@ -63,6 +63,55 @@ Comments Plugin Styles
 	clear: both;
 }
 .comment-list {
-  padding-left: 0;
+  padding-left: 0px;
   list-style: none;
+}
+.comment-flag-new {
+	background-color: lightcyan;
+}
+.comment-level-1 { margin-left: 20px; padding-left: 0px; border-left: gray solid 0px; }
+.comment-level-2 { margin-left: 40px; padding-left: 0px; border-left: gray solid 0px; }
+.comment-level-3 { margin-left: 60px; padding-left: 0px; border-left: gray solid 0px; }
+.comment-level-4 { margin-left: 80px; padding-left: 0px; border-left: gray solid 0px; }
+.comment-level-5 { margin-left: 100px; padding-left: 0px; border-left: gray solid 0px; }
+.row.comments { position: relative; }
+.comment-level-1::before {
+    content: "\f105";
+    font-family: FontAwesome;
+    position: absolute;
+    left: 0px;
+    font-size: 3rem;
+    color: lightgray;
+}
+.comment-level-2::before {
+    content: "\f105\f105";
+    font-family: FontAwesome;
+    position: absolute;
+    left: 0px;
+    font-size: 3rem;
+    color: lightgray;
+}
+.comment-level-3::before {
+    content: "\f105\f105\f105";
+    font-family: FontAwesome;
+    position: absolute;
+    left: 0px;
+    font-size: 3rem;
+    color: lightgray;
+}
+.comment-level-4::before {
+    content: "\f105\f105\f105\f105";
+    font-family: FontAwesome;
+    position: absolute;
+    left: 0px;
+    font-size: 3rem;
+    color: lightgray;
+}
+.comment-level-5::before {
+    content: "\f105\f105\f105\f105\f105";
+    font-family: FontAwesome;
+    position: absolute;
+    left: 0px;
+    font-size: 3rem;
+    color: lightgray;
 }

--- a/assets/comments.css
+++ b/assets/comments.css
@@ -1,0 +1,68 @@
+/*
+===============================================================================================================================
+Comments Plugin Styles
+===============================================================================================================================
+*/
+
+.comment {
+	margin-top: 15px;
+	border-top: gray solid 2px;
+}
+.comment:first-child {
+  margin-top: 0;
+}
+.comment,
+.comment-body {
+  zoom: 1;
+  overflow: hidden;
+}
+.comment-body {
+  width: 10000px;
+}
+.comment-object {
+  display: block;
+}
+.comment-right,
+.comment > .pull-right {
+  padding-left: 10px;
+}
+.comment-left,
+.comment > .pull-left {
+  padding-right: 10px;
+}
+.comment-left,
+.comment-right,
+.comment-body {
+  display: table-cell;
+  vertical-align: top;
+}
+.comment-middle {
+  vertical-align: middle;
+}
+.comment-bottom {
+  vertical-align: bottom;
+}
+.comment-heading {
+  margin-top: 0;
+  margin-bottom: 5px;
+  border-bottom: gray dashed 1px;
+}
+.comment-title, .comment-title h4 {
+	padding: 0px;
+	margin: 0px;
+}
+.comment-meta {
+	display: inline;
+	font-size: small;
+}
+.comment-reply {
+	display: inline;
+	float: right;
+}
+.comment-text {
+	clear: both;
+}
+.comment-list {
+  padding-left: 0;
+  list-style: none;
+}

--- a/assets/comments.js
+++ b/assets/comments.js
@@ -1,0 +1,83 @@
+$(document).ready(function () {
+
+    function PhpComment(element) {
+        this.element = element;
+        this.init();
+    }
+
+    PhpComment.prototype.init = function () {
+        this.setupVariables();
+        this.setupEvents();
+    }
+
+    PhpComment.prototype.setupVariables = function () {
+        this.commentForm = this.element.find(".comment-form");
+        this.titleField = this.element.find("#comment_title");
+        this.bodyField = this.element.find("#comment_body");
+    }
+
+    PhpComment.prototype.setupEvents = function () {
+        var phpComment = this,
+        newMedia;
+
+        $.ajax({
+            url: '/media_template.php',
+            method: 'GET',
+            dataType: 'html',
+            success: function (data) {
+                newMedia = data;
+            }
+        });
+
+        phpComment.commentForm.on("submit", function (e) {
+            e.preventDefault();
+            var parentId = 0,
+                title = phpComment.titleField.val(),
+                body = phpComment.bodyField.val();
+
+            if(phpComment.commentForm.parents(".media").length > 0){
+                parentId = phpComment.commentForm.closest(".media").attr("data-Id");
+            }
+
+            $.ajax({
+                url: phpComment.commentForm.attr("action"),
+                method: 'POST',
+                dataType: 'json',
+                data: {title: title, body: body, parentId: parentId},
+                success: function (data) {
+                    if(!data.created){
+                        alert("Couldn't create comment");
+                        return;
+                    }
+
+                    newMedia = newMedia.replace("{{id}}", data.id);
+                    newMedia = newMedia.replace("{{title}}", title);
+                    newMedia = newMedia.replace("{{body}}", body);
+                    newMedia = newMedia.replace("{{nested}}", '');
+                    phpComment.commentForm.before(newMedia);
+                    phpComment.titleField.val("");
+                    phpComment.bodyField.val("");
+                }
+            });
+        });
+
+        $(document).on("click", ".comment-add-new", function (e) {
+            e.preventDefault();
+            var media = $(this).closest(".comments");
+            media.find(">.comment-body>.comment-text").after(phpComment.commentForm);
+        });
+        $(document).on("click", ".comment-add-reply", function (e) {
+            e.preventDefault();
+            var media = $(this).closest(".comment");
+            media.find(">.comment-body>.comment-text").after(phpComment.commentForm);
+        });
+    }
+
+    $.fn.phpComment = function (options) {
+        new PhpComment(this);
+        return this;
+    }
+
+    $(".comments").phpComment();
+
+});

--- a/assets/comments.js
+++ b/assets/comments.js
@@ -11,7 +11,7 @@ $(document).ready(function () {
     }
 
     PhpComment.prototype.setupVariables = function () {
-        this.commentForm = this.element.find(".comment-form");
+        this.commentForm = this.element.find(".comments-form");
         this.titleField = this.element.find("#comment_title");
         this.bodyField = this.element.find("#comment_body");
     }
@@ -35,8 +35,8 @@ $(document).ready(function () {
                 title = phpComment.titleField.val(),
                 body = phpComment.bodyField.val();
 
-            if(phpComment.commentForm.parents(".media").length > 0){
-                parentId = phpComment.commentForm.closest(".media").attr("data-Id");
+            if(phpComment.commentForm.parents(".comment").length > 0){
+                parentId = phpComment.commentForm.closest(".comment").attr("data-Id");
             }
 
             $.ajax({
@@ -63,8 +63,7 @@ $(document).ready(function () {
 
         $(document).on("click", ".comment-add-new", function (e) {
             e.preventDefault();
-            var media = $(this).closest(".comments");
-            media.find(">.comment-body>.comment-text").after(phpComment.commentForm);
+            $(this).find(".comments").before(phpComment.commentForm);
         });
         $(document).on("click", ".comment-add-reply", function (e) {
             e.preventDefault();

--- a/assets/comments.js
+++ b/assets/comments.js
@@ -1,82 +1,130 @@
-$(document).ready(function () {
-
-    function PhpComment(element) {
-        this.element = element;
-        this.init();
+jQuery(document).ready(function () {
+  var commentForm = $(document).find('.comments-form');
+  var commentSection = $(document).find('.comments').first();
+  var commentAlert = commentForm.closest('.alert');
+  //var newMedia;
+  //hide form, show link
+  commentForm.hide();
+  $(document).find('.comment-add-new').show();
+  //get template for inserting new comments
+  /* 
+$.ajax({
+	url: '/media_template.php',
+	method: 'GET',
+	dataType: 'html',
+	success: function (data) {
+		newMedia = data;
+	}
+});
+ */
+  $('body').on('click', '.comment-add-new-sadf', function (e) {
+    e.preventDefault();
+    alert('asdf');
+    $('span').stop().css('opacity', 1).text('myName = ' + e.name).fadeIn(30).fadeOut(1000);
+  });
+  //show comment form above comments section (new comment thread)
+  $('body').on('click', '.comment-add-new', function (e) {
+    e.preventDefault();
+    //commentForm.hide(1000);
+    //commentSection.before(commentForm);
+    $(this).before(commentForm);
+    commentForm.show('slow');
+    //$(this).slideUp();
+  });
+  //show comment form below selected comment (reply to existing comment)
+  $('body').on('click', '.comment-add-reply', function (e) {
+    e.preventDefault();
+    var media = $(this).closest('.comment');
+    commentForm.hide();
+    media.find('>.comment-body>.comment-text').after(commentForm);
+    commentForm.show('slow');
+  });
+  // Attach a submit handler to the form
+  $(commentForm).on('submit', function (event) {
+    event.preventDefault();
+    // Get some values from elements on the page:
+    //var term = $(this).find( "input[name='s']" ).val();
+    //var data = $(this).serializeArray();
+    var data = $(this).serialize();
+		console.log("Form Data (submit)", JSON.parse(JSON.stringify(data)));
+    //var url = $(this).attr( "action" );
+    var url = '/nested-comments';
+    var parentId = 0;
+    if ($(this).parents('.comment').length > 0) {
+      parentId = $(this).closest('.comment').attr('data-Id');
     }
+    // Send the data using post
 
-    PhpComment.prototype.init = function () {
-        this.setupVariables();
-        this.setupEvents();
-    }
-
-    PhpComment.prototype.setupVariables = function () {
-        this.commentForm = this.element.find(".comments-form");
-        this.titleField = this.element.find("#comment_title");
-        this.bodyField = this.element.find("#comment_body");
-    }
-
-    PhpComment.prototype.setupEvents = function () {
-        var phpComment = this,
-        newMedia;
-
-        $.ajax({
-            url: '/media_template.php',
-            method: 'GET',
-            dataType: 'html',
-            success: function (data) {
-                newMedia = data;
-            }
-        });
-
-        phpComment.commentForm.on("submit", function (e) {
-            e.preventDefault();
-            var parentId = 0,
-                title = phpComment.titleField.val(),
-                body = phpComment.bodyField.val();
-
-            if(phpComment.commentForm.parents(".comment").length > 0){
-                parentId = phpComment.commentForm.closest(".comment").attr("data-Id");
-            }
-
-            $.ajax({
-                url: phpComment.commentForm.attr("action"),
-                method: 'POST',
-                dataType: 'json',
-                data: {title: title, body: body, parentId: parentId},
-                success: function (data) {
-                    if(!data.created){
-                        alert("Couldn't create comment");
-                        return;
-                    }
-
-                    newMedia = newMedia.replace("{{id}}", data.id);
-                    newMedia = newMedia.replace("{{title}}", title);
-                    newMedia = newMedia.replace("{{body}}", body);
-                    newMedia = newMedia.replace("{{nested}}", '');
-                    phpComment.commentForm.before(newMedia);
-                    phpComment.titleField.val("");
-                    phpComment.bodyField.val("");
-                }
-            });
-        });
-
-        $(document).on("click", ".comment-add-new", function (e) {
-            e.preventDefault();
-            $(this).find(".comments").before(phpComment.commentForm);
-        });
-        $(document).on("click", ".comment-add-reply", function (e) {
-            e.preventDefault();
-            var media = $(this).closest(".comment");
-            media.find(">.comment-body>.comment-text").after(phpComment.commentForm);
-        });
-    }
-
-    $.fn.phpComment = function (options) {
-        new PhpComment(this);
-        return this;
-    }
-
-    $(".comments").phpComment();
-
+    //var posting = $.post(url, { parentId: parentId, data: data }, null, 'json');
+    var posting = $.post(url, data + '&parentID=' + parentId, null, 'json');
+    //$.post( "test.php", $( "#testform" ).serialize() );
+    // Put the results in a div
+    posting.done(function (response) {
+      alert('success');
+		console.log("Response Data (done)", JSON.parse(JSON.stringify(response)));
+      //response = JSON.parse(response);
+      var message = response.status ? response.message : 'Error: ' + response.message;
+      commentForm.after(commentAlert);
+      commentAlert.empty().append(message);
+      if (!response.status) {
+        return;
+      }
+      if (response.status) {
+		var newMedia = `
+				<div class='comment comment-level-{{comment.level|e}}' data-Id='{{comment.id}}' >
+				  <div class='comment-left'>
+					<a href='#'>
+					  <img class='comment-object' src='https://www.gravatar.com/avatar/{{comment.email|trim|lower|md5}}?d=identicon' alt='user icon'>
+					</a>
+				  </div>
+				  <div class='comment-body'>
+					<div class='comment-heading'>
+						<div class='comment-title'><h4>{{comment.title}}</h4></div>
+						<div class='comment-reply'><a class='comment-add-reply' href='#'>{{'PLUGIN_COMMENTS.ADD_REPLY'|t}}</a></div>
+						<div class='comment-meta'>{{'PLUGIN_COMMENTS.WRITTEN_ON'|t}} {{comment.date|e}} {{'PLUGIN_COMMENTS.BY'|t}} {{comment.author}}</div>
+					</div>
+					<div class='comment-text' >
+						{{comment.text}}
+					</div>
+					{{nested}}
+				  </div>
+				</div>
+`;
+        newMedia = newMedia.replace('{{comment.id}}', response.id);
+        newMedia = newMedia.replace('{{comment.level|e}}', response.level);
+        newMedia = newMedia.replace('{{comment.email|trim|lower|md5}}', response.hash);
+        newMedia = newMedia.replace('{{parent_id}}', response.data.parent_id);
+        newMedia = newMedia.replace('{{comment.title}}', response.data.title);
+        newMedia = newMedia.replace('{{comment.text}}', response.data.text);
+        newMedia = newMedia.replace('{{comment.author}}', response.data.name);
+        //newMedia = newMedia.replace('{{comment.date|e}}', response.data.name);
+		if ($( "div[data-Id='" + response.data.parent_id + "']" ).length > 0) {
+			$( "div[data-Id='" + response.data.parent_id + "']" ).first().after(newMedia);
+		} else {
+			$( "div.comments" ).last().prepend(newMedia);
+		}
+        //phpComment.commentForm.before(newMedia);
+        //phpComment.titleField.val("");
+        //phpComment.bodyField.val("");
+      }
+      setTimeout(function () {
+        commentForm.hide(3000);
+      }, 5000);
+    });
+    posting.fail(function (status, error, title) {
+      alert('error');
+		console.log("Response Data (fail)", JSON.parse(JSON.stringify(status)));
+      commentForm.after(commentAlert);
+      commentAlert.empty().append("<p>TEST</p>");
+      commentAlert.append("<p>" + status + "</p>");
+      commentAlert.append("<p>" + error + "</p>");
+      commentAlert.append("<p>" + title + "</p>");
+    });
+    posting.always(function (test) {
+      //alert("finished, be it successful or not");
+      //test = JSON.parse(test);
+      //test = test.serialize();
+	  //alert(test);
+    });
+  });
 });

--- a/class/Comment.php
+++ b/class/Comment.php
@@ -28,7 +28,8 @@ class Comment
 		$comments[] = $this->value;
 		
 		foreach($this->children as $child) {
-			$comments[] = $child->getContent($level + 1);
+			//$comments[] = $child->getContent($level + 1); //produces nested result array.
+			$comments = array_merge($comments, $child->getContent($level + 1)); //produces flat result array.
 		}
 		return $comments;
     }

--- a/class/Comment.php
+++ b/class/Comment.php
@@ -1,0 +1,41 @@
+<?php
+
+class Comment 
+{
+    private $id = 0;
+    private $value = array();
+    private $parent = null;
+    private $children = array();
+
+	public function __construct($id, $content) {
+		$this->id = $id;
+		$this->value = $content;
+	}
+	
+    public function addItem($obj, $key = null) {
+    }
+
+    public function deleteItem($key) {
+    }
+
+    public function getItem($key) {
+    }
+
+    public function getContent($level = 0) {
+		$comments = $this->value;
+		$comments['level'] = $level;
+		
+		foreach($this->children as $child) {
+			array_merge($comments, $child->getContent($level + 1));
+		}
+		return $comments;
+    }
+
+	public function setParent($parent) {
+		$this->parent = $parent;
+    }
+    public function addSubComment($obj) {
+		$this->children[] = $obj;
+    }
+
+}

--- a/class/Comment.php
+++ b/class/Comment.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Grav\Plugin;
+
 class Comment 
 {
     private $id = 0;
@@ -22,11 +24,11 @@ class Comment
     }
 
     public function getContent($level = 0) {
-		$comments = $this->value;
-		$comments['level'] = $level;
+		$this->value['level'] = $level;
+		$comments[] = $this->value;
 		
 		foreach($this->children as $child) {
-			array_merge($comments, $child->getContent($level + 1));
+			$comments[] = $child->getContent($level + 1);
 		}
 		return $comments;
     }

--- a/comments.php
+++ b/comments.php
@@ -16,7 +16,8 @@ use RocketTheme\Toolbox\Event\Event;
 use RocketTheme\Toolbox\File\File;
 use Symfony\Component\Yaml\Yaml;
 
-require_once 'class\Comment.php';
+require_once '/html/apps/grav/user/plugins/comments/class/Comment.php';
+use Grav\Plugin\Comment;
 
 class CommentsPlugin extends Plugin
 {
@@ -404,7 +405,7 @@ class CommentsPlugin extends Plugin
         $filename .= $this->grav['uri']->path() . '.yaml';
 
         $comments = $this->getDataFromFilename($filename)['comments'];
-		$comments = setCommentLevels($comments);
+		$comments = $this->setCommentLevels($comments);
         //save to cache if enabled
         $cache->save($this->comments_cache_id, $comments);
         return $comments;
@@ -414,11 +415,8 @@ class CommentsPlugin extends Plugin
      * Return the latest commented pages
      */
     private function setCommentLevels($comments) {
-		$levels = array();
 		$levelsflat = array();
 		foreach($comments as $key => $comment) {
-			//$comments[$key]['level'] = 0;
-			$levels[$comment['parent']][] = $comment['id'];
 			$levelsflat[$comment['id']]['parent'] = $comment['parent'];
 			$levelsflat[$comment['id']]['class'] = new Comment($comment['id'], $comments[$key]);
 		}
@@ -426,11 +424,8 @@ class CommentsPlugin extends Plugin
 		$leveltree = array();
 		foreach($levelsflat as $id => $parent) {
 			$parent_id = $parent['parent'];
-			if(!isset($levelsflat[$parent_id]){
+			if(!isset($levelsflat[$parent_id])){
 				$leveltree[$id] = $levelsflat[$id]['class'];
-				//$leveltree[$id] = array();
-				//$leveltree[$id]['level'] = 0;
-				//$leveltree[$id]['children'] = array();
 			} else {
 				$currentParent = $levelsflat[$parent_id]['class'];
 				$currentChild = $levelsflat[$id]['class'];
@@ -441,7 +436,7 @@ class CommentsPlugin extends Plugin
 		//reset comment values to nested order
 		$comments = array();
 		foreach($leveltree as $id => $comment) {
-			array_merge($comments, $comment->getContent);
+			$comments = array_merge($comments, $comment->getContent());
 		}
 		return $comments;
     }

--- a/comments.php
+++ b/comments.php
@@ -96,6 +96,7 @@ class CommentsPlugin extends Plugin
 
         if ($this->enable) {
             $this->enable([
+                'onPageInitialized' => ['onPageInitialized', 0],
                 'onFormProcessed' => ['onFormProcessed', 0],
                 'onFormPageHeaderProcessed' => ['onFormPageHeaderProcessed', 0],
                 'onTwigSiteVariables' => ['onTwigSiteVariables', 0]
@@ -149,6 +150,31 @@ class CommentsPlugin extends Plugin
             $this->initializeFrontend();
         }
     }
+
+    /**
+     * Handle ajax call.
+     */
+    public function onPageInitialized()
+    {
+        // initialize with page settings (post-cache)
+//        if (!$this->isAdmin() && isset($this->grav['page']->header()->{'star-ratings'})) {
+//			// if not in admin merge potential page-level configs
+//            $this->config->set('plugins.star-ratings', $this->mergeConfig($page));
+//        }
+        $this->callback = 'nested-comments';
+//        $this->callback = $this->config->get('plugins.star-ratings.callback');
+//        $this->total_stars = $this->config->get('plugins.star-ratings.total_stars');
+//        $this->only_full_stars = $this->config->get('plugins.star-ratings.only_full_stars');
+
+        // Process vote if required
+        if ($this->callback === $this->grav['uri']->path()) {
+            // try to add the vote
+            $result = $this->addVote();
+            echo json_encode(['status' => $result[0], 'message' => $result[1], 'data' => ['score' => $result[2][0], 'count' => $result[2][1]]]);
+            exit();
+        }
+    }
+
 
     /**
      * Handle form processing instructions.

--- a/comments.yaml
+++ b/comments.yaml
@@ -1,13 +1,12 @@
 enabled: true
-
+built_in_css: true
+ajax_callback: /nested-comments
 enable_on_routes:
   - '/blog'
-
 disable_on_routes:
   - /blog/blog-post-to-ignore
   - /ignore-this-route
   #- '/blog/daring-fireball-link'
-
 form:
     name: comments
     fields:

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,6 +1,10 @@
 de:
   PLUGIN_COMMENTS:
+    ADD_NEW: Kommentar hinzufügen
+    ADD_REPLY: Antworten
     ADD_COMMENT: Kommentar hinzufügen
+    DELETE_COMMENT: Kommentar löschen
+    SUCCESS: Der Kommentar wurde erfolgreich gespeichert.
     COMMENTS: Kommentare
     EMAIL_NOT_CONFIGURED: Email nicht konfiguriert
     NEW_COMMENT_EMAIL_SUBJECT: 'Neuer Kommentar für %1$s'
@@ -22,7 +26,11 @@ de:
 
 en:
   PLUGIN_COMMENTS:
+    ADD_NEW: Add a comment
+    ADD_REPLY: Reply
     ADD_COMMENT: Add a comment
+    DELETE_COMMENT: Delete comment
+    SUCCESS: Comment has been saved successfully.
     COMMENTS: Comments
     EMAIL_NOT_CONFIGURED: Email not configured
     NEW_COMMENT_EMAIL_SUBJECT: 'New comment on %1$s'

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,10 +1,12 @@
 de:
   PLUGIN_COMMENTS:
     ADD_NEW: Kommentar hinzufügen
-    ADD_REPLY: Antworten
+    ADD_REPLY: Auf Kommentar antworten
     ADD_COMMENT: Kommentar hinzufügen
     DELETE_COMMENT: Kommentar löschen
-    SUCCESS: Der Kommentar wurde erfolgreich gespeichert.
+    REPLY: Antworten
+    DELETE: Löschen
+    SUCCESS: "Der Kommentar wurde erfolgreich gespeichert."
     COMMENTS: Kommentare
     EMAIL_NOT_CONFIGURED: Email nicht konfiguriert
     NEW_COMMENT_EMAIL_SUBJECT: 'Neuer Kommentar für %1$s'
@@ -27,10 +29,12 @@ de:
 en:
   PLUGIN_COMMENTS:
     ADD_NEW: Add a comment
-    ADD_REPLY: Reply
+    ADD_REPLY: Reply to comment
     ADD_COMMENT: Add a comment
     DELETE_COMMENT: Delete comment
-    SUCCESS: Comment has been saved successfully.
+    REPLY: Reply
+    DELETE: Delete
+    SUCCESS: "Comment has been saved successfully."
     COMMENTS: Comments
     EMAIL_NOT_CONFIGURED: Email not configured
     NEW_COMMENT_EMAIL_SUBJECT: 'New comment on %1$s'

--- a/templates/partials/comments.form.html.twig
+++ b/templates/partials/comments.form.html.twig
@@ -32,7 +32,7 @@
         {% endfor %}
         </div>
 
-        {{ nonce_field('form', 'form-nonce')|raw }}
+        {{ nonce_field('comments', 'form-nonce')|raw }}
     </form>
 
     <div class="alert">{{ form.message }}</div>

--- a/templates/partials/comments.form.html.twig
+++ b/templates/partials/comments.form.html.twig
@@ -1,5 +1,5 @@
     <h3>{{'PLUGIN_COMMENTS.ADD_COMMENT'|t}}</h3>
-    <form name="{{ grav.config.plugins.comments.form.name }}"
+    <form name="{{ grav.config.plugins.comments.form.name }}" class="comments-form"
           action="{{ grav.config.plugins.comments.form.action ?  base_url ~ grav.config.plugins.comments.form.action : page.url }}"
           method="{{ grav.config.plugins.comments.form.method|upper|default('POST') }}">
 

--- a/templates/partials/comments.form.html.twig
+++ b/templates/partials/comments.form.html.twig
@@ -1,5 +1,4 @@
-    <h3>{{'PLUGIN_COMMENTS.ADD_COMMENT'|t}}</h3>
-    <form name="{{ grav.config.plugins.comments.form.name }}" class="comments-form"
+    <form id="comments-form" name="{{ grav.config.plugins.comments.form.name }}" class="comments-form"
           action="{{ grav.config.plugins.comments.form.action ?  base_url ~ grav.config.plugins.comments.form.action : page.url }}"
           method="{{ grav.config.plugins.comments.form.method|upper|default('POST') }}">
 
@@ -35,4 +34,4 @@
         {{ nonce_field('comments', 'form-nonce')|raw }}
     </form>
 
-    <div class="alert">{{ form.message }}</div>
+    <div id="comments-alert" class="alert">{{ form.message }}</div>

--- a/templates/partials/comments.html.twig
+++ b/templates/partials/comments.html.twig
@@ -8,7 +8,7 @@
         <h3>{{'PLUGIN_COMMENTS.COMMENTS'|t}}</h3>
 		<a class="comment-add-new" href="#">{{'PLUGIN_COMMENTS.ADD_NEW'|t}}</a>
             <div class="row comments">
-            {% for comment in grav.twig.comments|array_reverse %}
+            {% for comment in grav.twig.comments %}
 				<div class="comment comment-level-{{comment.level|e}}" data-Id="{{comment.id}}" >
 				  <div class="comment-left">
 					<a href="#">

--- a/templates/partials/comments.html.twig
+++ b/templates/partials/comments.html.twig
@@ -6,10 +6,10 @@
     {% if grav.twig.comments|length %}
 
         <h3>{{'PLUGIN_COMMENTS.COMMENTS'|t}}</h3>
-		<a class="comment-add-new" href="#">{{'PLUGIN_COMMENTS.ADD_NEW'|t}}</a>
+		<a class="comment-add-new" href="#"><i class="fa fa-plus" title="{{'PLUGIN_COMMENTS.ADD_NEW'|t}}"></i> {{'PLUGIN_COMMENTS.ADD_NEW'|t}}</a>
             <div class="row comments">
             {% for comment in grav.twig.comments %}
-				<div class="comment comment-level-{{comment.level|e}}" data-Id="{{comment.id}}" >
+				<div class="comment comment-level-{{comment.level|e}}" data-level="{{comment.level}}" data-id="{{comment.id}}" >
 				  <div class="comment-left">
 					<a href="#">
 					  <img class="comment-object" src="https://www.gravatar.com/avatar/{{comment.email|trim|lower|md5}}?d=identicon" alt="user icon">
@@ -18,7 +18,12 @@
 				  <div class="comment-body">
 					<div class="comment-heading">
 						<div class="comment-title"><h4>{{comment.title}}</h4></div>
-						<div class="comment-reply"><a class="comment-add-reply" href="#">{{'PLUGIN_COMMENTS.ADD_REPLY'|t}}</a></div>
+						<div class="comment-reply">
+							<a class="comment-add-reply" href="#"><i class="fa fa-reply" title="{{'PLUGIN_COMMENTS.ADD_REPLY'|t}}"></i> {{'PLUGIN_COMMENTS.ADD_REPLY'|t}}</a>
+							{% if grav.user.access.admin.super %}
+							<a class="comment-delete" href="#"><i class="fa fa-trash" title="{{'PLUGIN_COMMENTS.DELETE'|t}}"></i> {{'PLUGIN_COMMENTS.DELETE'|t}}</a>
+							{% endif %}
+						</div>
 						<div class="comment-meta">{{'PLUGIN_COMMENTS.WRITTEN_ON'|t}} {{comment.date|e}} {{'PLUGIN_COMMENTS.BY'|t}} {{comment.author}}</div>
 					</div>
 					<div class="comment-text" >

--- a/templates/partials/comments.html.twig
+++ b/templates/partials/comments.html.twig
@@ -1,27 +1,27 @@
 {% if grav.twig.enable_comments_plugin %}
     {% set scope = scope ?: 'data.' %}
+    <section id="comments-section">
+        <h2>{{'PLUGIN_COMMENTS.COMMENTS'|t}}</h3>
+    	<!-- <h2>{{ 'COMMENTS'|t }}</h2> -->
 
     {% include 'partials/comments.form.html.twig' %}
 
     {% if grav.twig.comments|length %}
 
-        <h3>{{'PLUGIN_COMMENTS.COMMENTS'|t}}</h3>
 		<a class="comment-add-new" href="#"><i class="fa fa-plus" title="{{'PLUGIN_COMMENTS.ADD_NEW'|t}}"></i> {{'PLUGIN_COMMENTS.ADD_NEW'|t}}</a>
             <div class="row comments">
             {% for comment in grav.twig.comments %}
 				<div class="comment comment-level-{{comment.level|e}}" data-level="{{comment.level}}" data-id="{{comment.id}}" >
 				  <div class="comment-left">
-					<a href="#">
 					  <img class="comment-object" src="https://www.gravatar.com/avatar/{{comment.email|trim|lower|md5}}?d=identicon" alt="user icon">
-					</a>
 				  </div>
 				  <div class="comment-body">
 					<div class="comment-heading">
 						<div class="comment-title"><h4>{{comment.title}}</h4></div>
 						<div class="comment-reply">
-							<a class="comment-add-reply" href="#"><i class="fa fa-reply" title="{{'PLUGIN_COMMENTS.ADD_REPLY'|t}}"></i> {{'PLUGIN_COMMENTS.ADD_REPLY'|t}}</a>
+							<a class="comment-add-reply" href="#"><i class="fa fa-reply" title="{{'PLUGIN_COMMENTS.ADD_REPLY'|t}}"></i> {{'PLUGIN_COMMENTS.REPLY'|t}}</a>
 							{% if grav.user.access.admin.super %}
-							<a class="comment-delete" href="#"><i class="fa fa-trash" title="{{'PLUGIN_COMMENTS.DELETE'|t}}"></i> {{'PLUGIN_COMMENTS.DELETE'|t}}</a>
+							<a class="comment-delete" href="#"><i class="fa fa-trash" title="{{'PLUGIN_COMMENTS.DELETE_COMMENT'|t}}"></i> {{'PLUGIN_COMMENTS.DELETE'|t}}</a>
 							{% endif %}
 						</div>
 						<div class="comment-meta">{{'PLUGIN_COMMENTS.WRITTEN_ON'|t}} {{comment.date|e}} {{'PLUGIN_COMMENTS.BY'|t}} {{comment.author}}</div>
@@ -36,6 +36,7 @@
             </div>
 
     {% endif %}
+    </section>
 {% endif %}
 
 

--- a/templates/partials/comments.html.twig
+++ b/templates/partials/comments.html.twig
@@ -6,6 +6,7 @@
     {% if grav.twig.comments|length %}
 
         <h3>{{'PLUGIN_COMMENTS.COMMENTS'|t}}</h3>
+		<a class="comment-add-new" href="#">{{'PLUGIN_COMMENTS.ADD_NEW'|t}}</a>
             <div class="row comments">
             {% for comment in grav.twig.comments|array_reverse %}
 				<div class="comment comment-level-{{comment.level|e}}" data-Id="{{comment.id}}" >
@@ -17,7 +18,7 @@
 				  <div class="comment-body">
 					<div class="comment-heading">
 						<div class="comment-title"><h4>{{comment.title}}</h4></div>
-						<div class="comment-reply"><a class="reply-link" href="#">Reply</a></div>
+						<div class="comment-reply"><a class="comment-add-reply" href="#">{{'PLUGIN_COMMENTS.ADD_REPLY'|t}}</a></div>
 						<div class="comment-meta">{{'PLUGIN_COMMENTS.WRITTEN_ON'|t}} {{comment.date|e}} {{'PLUGIN_COMMENTS.BY'|t}} {{comment.author}}</div>
 					</div>
 					<div class="comment-text" >


### PR DESCRIPTION
Hi there,

added some functionality for my own use. Since some of it is listed in #22 you might be able to reuse some of it, namely:

- ajax submission
- gravatar support
- styling
- nested comments
- delete comments as admin,super (from frontend)

Two things to be aware of:
- I don't care about the backend presentation (admin panel) so that's most likely broken.
- I changed the save logic to use the current page folder which is my personal preference. Comments are stored with the markdown file they belong to, Mainly because of three reasons:
  1. changing routes doesn't orphan comments
  2. deleting pages physically deletes the corresponding comments
  3. comments are git-synced

Should be seen as WIP as it is _not_ heavily tested.

Regards,
Thorsten

**Screenshot 1:**
![image](https://user-images.githubusercontent.com/23580812/31979224-d682e42a-b945-11e7-98cb-81900883a77d.png)

**Screenshot 2:**
![image](https://user-images.githubusercontent.com/23580812/31979175-8b9f8d28-b945-11e7-8199-e6d172165cef.png)