### PR TITLE
Use new way of using comments in twig template

### DIFF
--- a/templates/partials/comments.html.twig
+++ b/templates/partials/comments.html.twig
@@ -41,7 +41,7 @@
 
     <div class="alert">{{ form.message }}</div>
 
-    {% if grav.twig.comments|length %}
+    {% if comments|length %}
 
         <h3>{{'PLUGIN_COMMENTS.COMMENTS'|t}}</h3>
 


### PR DESCRIPTION
This was introduced in 0683d9322284f19eef56f3af2c22bfc336c7ab57 but the line mentioned was missed I guess.