### PR TITLE
Fix auto-escape on output of validation alerts

### DIFF
--- a/templates/partials/comments.html.twig
+++ b/templates/partials/comments.html.twig
@@ -39,7 +39,7 @@
         {{ nonce_field('form', 'form-nonce')|raw }}
     </form>
 
-    <div class="alert">{{ form.message }}</div>
+    <div class="alert">{{ form.message | raw }}</div>
 
     {% if grav.twig.comments|length %}
 


### PR DESCRIPTION
Validation alerts are not displayed properly without `|raw`