### PR TITLE
Add quotes around the strings for example disabled routes

### DIFF
--- a/comments.yaml
+++ b/comments.yaml
@@ -4,8 +4,8 @@ enable_on_routes:
   - '/blog'
 
 disable_on_routes:
-  - /blog/blog-post-to-ignore
-  - /ignore-this-route
+  - '/blog/blog-post-to-ignore'
+  - '/ignore-this-route'
   #- '/blog/daring-fireball-link'
 
 form:


### PR DESCRIPTION
The example comments.yaml file doesn't have quotes around the example disable_on_routes strings and this is causing problems with submitting comments. Adding the quotes to the examples fixes comment submission.
Tested with Grav v1.7.27 and PHP 7.4.13.
